### PR TITLE
Fix debug-success listener to prevent memory leaks

### DIFF
--- a/dist-electron/preload.js
+++ b/dist-electron/preload.js
@@ -59,9 +59,10 @@ electron_1.contextBridge.exposeInMainWorld("electronAPI", {
         };
     },
     onDebugSuccess: (callback) => {
-        electron_1.ipcRenderer.on("debug-success", (_event, data) => callback(data));
+        const subscription = (_event, data) => callback(data);
+        electron_1.ipcRenderer.on("debug-success", subscription);
         return () => {
-            electron_1.ipcRenderer.removeListener("debug-success", (_event, data) => callback(data));
+            electron_1.ipcRenderer.removeListener("debug-success", subscription);
         };
     },
     onDebugError: (callback) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -101,11 +101,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   },
 
   onDebugSuccess: (callback: (data: any) => void) => {
-    ipcRenderer.on("debug-success", (_event, data) => callback(data))
+    const subscription = (_event: any, data: any) => callback(data)
+    ipcRenderer.on("debug-success", subscription)
     return () => {
-      ipcRenderer.removeListener("debug-success", (_event, data) =>
-        callback(data)
-      )
+      ipcRenderer.removeListener("debug-success", subscription)
     }
   },
   onDebugError: (callback: (error: string) => void) => {


### PR DESCRIPTION
## Summary
- store `debug-success` listener in a variable so removeListener uses the same reference

## Testing
- `npm test --prefix renderer`

------
https://chatgpt.com/codex/tasks/task_e_6864eda069ac8326a18cce51e4c869db