### PR TITLE
Update Electron API types

### DIFF
--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -22,6 +22,7 @@ export interface ElectronAPI {
   moveWindowRight: () => Promise<void>
   analyzeAudioFromBase64: (data: string, mimeType: string) => Promise<{ text: string; timestamp: number }>
   analyzeAudioFile: (path: string) => Promise<{ text: string; timestamp: number }>
+  analyzeImageFile: (path: string) => Promise<{ text: string; timestamp: number }>
   quitApp: () => Promise<void>
 }
 


### PR DESCRIPTION
## Summary
- sync `analyzeImageFile` type with actual return value
- keep global `Window` augmentation

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: rimraf not found until dependencies installed; after `npm install`, build succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_6864f376dc088326a4452c853782364e