### PR TITLE
Update screenshot deletion types

### DIFF
--- a/src/_pages/Debug.tsx
+++ b/src/_pages/Debug.tsx
@@ -249,7 +249,7 @@ const Debug: React.FC<DebugProps> = ({ isProcessing, setIsProcessing }) => {
     setToastOpen(true)
   }
 
-  const handleDeleteExtraScreenshot = async (index: number) => {
+  const handleDeleteExtraScreenshot = async (index: number): Promise<void> => {
     const screenshotToDelete = extraScreenshots[index]
 
     try {

--- a/src/_pages/Queue.tsx
+++ b/src/_pages/Queue.tsx
@@ -55,7 +55,7 @@ const Queue: React.FC<QueueProps> = ({ setView }) => {
     setToastOpen(true)
   }
 
-  const handleDeleteScreenshot = async (index: number) => {
+  const handleDeleteScreenshot = async (index: number): Promise<void> => {
     const screenshotToDelete = screenshots[index]
 
     try {

--- a/src/_pages/Solutions.tsx
+++ b/src/_pages/Solutions.tsx
@@ -186,7 +186,7 @@ const Solutions: React.FC<SolutionsProps> = ({ setView }) => {
     setToastOpen(true)
   }
 
-  const handleDeleteExtraScreenshot = async (index: number) => {
+  const handleDeleteExtraScreenshot = async (index: number): Promise<void> => {
     const screenshotToDelete = extraScreenshots[index]
 
     try {

--- a/src/components/Queue/ScreenshotItem.tsx
+++ b/src/components/Queue/ScreenshotItem.tsx
@@ -9,7 +9,7 @@ interface Screenshot {
 
 interface ScreenshotItemProps {
   screenshot: Screenshot
-  onDelete: (index: number) => void
+  onDelete: (index: number) => Promise<void>
   index: number
   isLoading: boolean
 }

--- a/src/components/Queue/ScreenshotQueue.tsx
+++ b/src/components/Queue/ScreenshotQueue.tsx
@@ -9,7 +9,7 @@ interface Screenshot {
 interface ScreenshotQueueProps {
   isLoading: boolean
   screenshots: Screenshot[]
-  onDeleteScreenshot: (index: number) => void
+  onDeleteScreenshot: (index: number) => Promise<void>
 }
 const ScreenshotQueue: React.FC<ScreenshotQueueProps> = ({
   isLoading,


### PR DESCRIPTION
## Summary
- let `ScreenshotItem` delete handler return a Promise
- update `ScreenshotQueue` delete prop type
- mark delete handlers as async in pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864fa0a96f4832688f175a2fab7944c