### PR TITLE
Update screenshot API type

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -26,7 +26,8 @@ interface ElectronAPI {
 
   onUnauthorized: (callback: () => void) => () => void
   onDebugError: (callback: (error: string) => void) => () => void
-  takeScreenshot: () => Promise<void>
+  // Capture a screenshot and return its file path and preview
+  takeScreenshot: () => Promise<{ path: string; preview: string }>
   moveWindowLeft: () => Promise<void>
   moveWindowRight: () => Promise<void>
   analyzeAudioFromBase64: (data: string, mimeType: string) => Promise<{ text: string; timestamp: number }>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -18,7 +18,8 @@ export interface ElectronAPI {
   onSolutionToken: (callback: (token: string) => void) => () => void
   onUnauthorized: (callback: () => void) => () => void
   onDebugError: (callback: (error: string) => void) => () => void
-  takeScreenshot: () => Promise<void>
+  // Capture a screenshot and return its file path and preview data
+  takeScreenshot: () => Promise<{ path: string; preview: string }>
   moveWindowLeft: () => Promise<void>
   moveWindowRight: () => Promise<void>
   analyzeAudioFromBase64: (data: string, mimeType: string) => Promise<{ text: string; timestamp: number }>


### PR DESCRIPTION
## Summary
- define `takeScreenshot` as returning the path and preview
- adjust preload API typing accordingly

## Testing
- `npx tsc --noEmit`
- `npx tsc -p electron/tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6865122e3c548326a583001cc1371bbb