### PR TITLE
fix: unify analyzeImageFile return type

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -32,7 +32,7 @@ interface ElectronAPI {
   moveWindowRight: () => Promise<void>
   analyzeAudioFromBase64: (data: string, mimeType: string) => Promise<{ text: string; timestamp: number }>
   analyzeAudioFile: (path: string) => Promise<{ text: string; timestamp: number }>
-  analyzeImageFile: (path: string) => Promise<void>
+  analyzeImageFile: (path: string) => Promise<{ text: string; timestamp: number }>
   quitApp: () => Promise<void>
 }
 


### PR DESCRIPTION
## Summary
- align preload `analyzeImageFile` definition with global electron types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68655637fd808326b819f900d6fb1778