### PR TITLE
Add ESLint flat config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,53 @@
+import js from '@eslint/js';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import importPlugin from 'eslint-plugin-import';
+import unused from 'eslint-plugin-unused-imports';
+import perfectionist from 'eslint-plugin-perfectionist';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: ['./tsconfig.json', './electron/tsconfig.json', './renderer/tsconfig.json'],
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs['recommended-type-checked'].rules,
+    },
+  },
+  {
+    plugins: {
+      react,
+      'react-hooks': reactHooks,
+      'jsx-a11y': jsxA11y,
+      import: importPlugin,
+      'unused-imports': unused,
+      perfectionist,
+    },
+    settings: {
+      react: { version: 'detect' },
+    },
+    rules: {
+      'react/react-in-jsx-scope': 'off',
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+      'import/order': ['error', { 'newlines-between': 'always' }],
+      'unused-imports/no-unused-imports': 'warn',
+      'perfectionist/sort-imports': ['warn', { type: 'alphabetical' }],
+    },
+  },
+  {
+    ignores: ['dist', 'dist-electron', 'node_modules'],
+  },
+];


### PR DESCRIPTION
## Summary
- add flat ESLint configuration for TypeScript and React projects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686563ae9f2c832682d70790faff3a1e