### PR TITLE
Enable LLM request cancellation

### DIFF
--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -13,6 +13,21 @@ export class LLMHelper {
     "extra_screenshots"
   )
 
+  private async withAbortSignal<T>(signal: AbortSignal, fn: () => Promise<T>): Promise<T> {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (input: any, init: any = {}) => {
+      const combined = init.signal
+        ? (AbortSignal as any).any([init.signal, signal])
+        : signal
+      return originalFetch(input, { ...init, signal: combined })
+    }
+    try {
+      return await fn()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  }
+
   private isPathInsideDir(filePath: string, dir: string): boolean {
     const relative = path.relative(dir, filePath)
     return !relative.startsWith("..") && !path.isAbsolute(relative)
@@ -73,7 +88,11 @@ export class LLMHelper {
     }
   }
 
-  public async generateSolution(problemInfo: any, onToken?: (token: string) => void) {
+  public async generateSolution(
+    problemInfo: any,
+    onToken?: (token: string) => void,
+    signal?: AbortSignal
+  ) {
     const prompt = `${this.systemPrompt}\n\nGiven this problem or situation:\n${JSON.stringify(problemInfo, null, 2)}\n\nPlease provide your response in the following JSON format:\n{
   "solution": {
     "code": "The code or main answer here.",
@@ -117,33 +136,40 @@ export class LLMHelper {
     }
   }
 
-  public async debugSolutionWithImages(problemInfo: any, currentCode: string, debugImagePaths: string[]) {
-    try {
-      const imageParts = await Promise.all(debugImagePaths.map(path => this.fileToGenerativePart(path)))
-      
-      const prompt = `${this.systemPrompt}\n\nYou are a wingman. Given:\n1. The original problem or situation: ${JSON.stringify(problemInfo, null, 2)}\n2. The current response or approach: ${currentCode}\n3. The debug information in the provided images\n\nPlease analyze the debug information and provide feedback in this JSON format:\n{
-  "solution": {
-    "code": "The code or main answer here.",
-    "problem_statement": "Restate the problem or situation.",
-    "context": "Relevant background/context.",
-    "suggested_responses": ["First possible answer or action", "Second possible answer or action", "..."],
-    "reasoning": "Explanation of why these suggestions are appropriate."
-  }
-}\nImportant: Return ONLY the JSON object, without any markdown formatting or code blocks.`
+  public async debugSolutionWithImages(
+    problemInfo: any,
+    currentCode: string,
+    debugImagePaths: string[],
+    signal?: AbortSignal
+  ) {
+    const exec = async () => {
+      try {
+        const imageParts = await Promise.all(
+          debugImagePaths.map((path) => this.fileToGenerativePart(path))
+        )
 
-      const result = await this.model.generateContent([prompt, ...imageParts])
-      const response = await result.response
-      const text = this.cleanJsonResponse(response.text())
-      const parsed = JSON.parse(text)
-      console.log("[LLMHelper] Parsed debug LLM response:", parsed)
-      return parsed
-    } catch (error) {
-      console.error("Error debugging solution with images:", error)
-      throw error
+        const prompt = `${this.systemPrompt}\n\nYou are a wingman. Given:\n1. The original problem or situation: ${JSON.stringify(
+          problemInfo,
+          null,
+          2
+        )}\n2. The current response or approach: ${currentCode}\n3. The debug information in the provided images\n\nPlease analyze the debug information and provide feedback in this JSON format:\n{\n  "solution": {\n    "code": "The code or main answer here.",\n    "problem_statement": "Restate the problem or situation.",\n    "context": "Relevant background/context.",\n    "suggested_responses": ["First possible answer or action", "Second possible answer or action", "..."],\n    "reasoning": "Explanation of why these suggestions are appropriate."\n  }\n}\nImportant: Return ONLY the JSON object, without any markdown formatting or code blocks.`
+
+        const result = await this.model.generateContent([prompt, ...imageParts])
+        const response = await result.response
+        const text = this.cleanJsonResponse(response.text())
+        const parsed = JSON.parse(text)
+        console.log("[LLMHelper] Parsed debug LLM response:", parsed)
+        return parsed
+      } catch (error) {
+        console.error("Error debugging solution with images:", error)
+        throw error
+      }
     }
+
+    return signal ? this.withAbortSignal(signal, exec) : exec()
   }
 
-  public async analyzeAudioFile(audioPath: string) {
+  public async analyzeAudioFile(audioPath: string, signal?: AbortSignal) {
     try {
       const resolved = this.validatePath(audioPath)
       const audioData = await fs.promises.readFile(resolved);
@@ -154,17 +180,24 @@ export class LLMHelper {
         }
       };
       const prompt = `${this.systemPrompt}\n\nDescribe this audio clip in a short, concise answer. In addition to your main answer, suggest several possible actions or responses the user could take next based on the audio. Do not return a structured JSON object, just answer naturally as you would to a user.`;
-      const result = await this.model.generateContent([prompt, audioPart]);
-      const response = await result.response;
-      const text = response.text();
-      return { text, timestamp: Date.now() };
+      const exec = async () => {
+        const result = await this.model.generateContent([prompt, audioPart])
+        const response = await result.response
+        const text = response.text()
+        return { text, timestamp: Date.now() }
+      }
+      return signal ? this.withAbortSignal(signal, exec) : await exec()
     } catch (error) {
       console.error("Error analyzing audio file:", error);
       throw error;
     }
   }
 
-  public async analyzeAudioFromBase64(data: string, mimeType: string) {
+  public async analyzeAudioFromBase64(
+    data: string,
+    mimeType: string,
+    signal?: AbortSignal
+  ) {
     try {
       const audioPart = {
         inlineData: {
@@ -173,17 +206,20 @@ export class LLMHelper {
         }
       };
       const prompt = `${this.systemPrompt}\n\nDescribe this audio clip in a short, concise answer. In addition to your main answer, suggest several possible actions or responses the user could take next based on the audio. Do not return a structured JSON object, just answer naturally as you would to a user and be concise.`;
-      const result = await this.model.generateContent([prompt, audioPart]);
-      const response = await result.response;
-      const text = response.text();
-      return { text, timestamp: Date.now() };
+      const exec = async () => {
+        const result = await this.model.generateContent([prompt, audioPart])
+        const response = await result.response
+        const text = response.text()
+        return { text, timestamp: Date.now() }
+      }
+      return signal ? this.withAbortSignal(signal, exec) : await exec()
     } catch (error) {
       console.error("Error analyzing audio from base64:", error);
       throw error;
     }
   }
 
-  public async analyzeImageFile(imagePath: string) {
+  public async analyzeImageFile(imagePath: string, signal?: AbortSignal) {
     try {
       const resolved = this.validatePath(imagePath)
       const imageData = await fs.promises.readFile(resolved);
@@ -194,10 +230,13 @@ export class LLMHelper {
         }
       };
       const prompt = `${this.systemPrompt}\n\nDescribe the content of this image in a short, concise answer. In addition to your main answer, suggest several possible actions or responses the user could take next based on the image. Do not return a structured JSON object, just answer naturally as you would to a user. Be concise and brief.`;
-      const result = await this.model.generateContent([prompt, imagePart]);
-      const response = await result.response;
-      const text = response.text();
-      return { text, timestamp: Date.now() };
+      const exec = async () => {
+        const result = await this.model.generateContent([prompt, imagePart])
+        const response = await result.response
+        const text = response.text()
+        return { text, timestamp: Date.now() }
+      }
+      return signal ? this.withAbortSignal(signal, exec) : await exec()
     } catch (error) {
       console.error("Error analyzing image file:", error);
       throw error;

--- a/electron/ProcessingHelper.ts
+++ b/electron/ProcessingHelper.ts
@@ -45,7 +45,10 @@ export class ProcessingHelper {
         mainWindow.webContents.send(this.appState.PROCESSING_EVENTS.INITIAL_START);
         this.appState.setView('solutions');
         try {
-          const audioResult = await this.llmHelper.analyzeAudioFile(lastPath);
+          const audioResult = await this.llmHelper.analyzeAudioFile(
+            lastPath,
+            this.currentProcessingAbortController.signal
+          );
           mainWindow.webContents.send(this.appState.PROCESSING_EVENTS.PROBLEM_EXTRACTED, audioResult);
           this.appState.setProblemInfo({ problem_statement: audioResult.text, input_format: {}, output_format: {}, constraints: [], test_cases: [] });
           return;
@@ -61,7 +64,10 @@ export class ProcessingHelper {
       this.appState.setView("solutions")
       this.currentProcessingAbortController = new AbortController()
       try {
-        const imageResult = await this.llmHelper.analyzeImageFile(lastPath);
+        const imageResult = await this.llmHelper.analyzeImageFile(
+          lastPath,
+          this.currentProcessingAbortController.signal
+        );
         const problemInfo = {
           problem_statement: imageResult.text,
           input_format: { description: "Generated from screenshot", parameters: [] as any[] },
@@ -106,7 +112,8 @@ export class ProcessingHelper {
             mainWindow.webContents.send(
               this.appState.PROCESSING_EVENTS.SOLUTION_TOKEN,
               token
-            )
+            ),
+          this.currentExtraProcessingAbortController.signal
         )
         const currentCode = currentSolution.solution.code
 
@@ -114,7 +121,8 @@ export class ProcessingHelper {
         const debugResult = await this.llmHelper.debugSolutionWithImages(
           problemInfo,
           currentCode,
-          extraScreenshotQueue
+          extraScreenshotQueue,
+          this.currentExtraProcessingAbortController.signal
         )
 
         this.appState.setHasDebugged(true)


### PR DESCRIPTION
## Summary
- wire AbortController signal through ProcessingHelper to LLMHelper
- add withAbortSignal helper to LLMHelper
- support AbortSignal in LLMHelper methods

## Testing
- `npm test`
- `npx tsc -p electron/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_686580d659308326b47dfeaa5dc1f912