### PR TITLE
Add Windows CI workflow

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,0 +1,54 @@
+name: Windows CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - ci/windows
+  pull_request:
+    branches:
+      - main
+      - ci/windows
+
+jobs:
+  build:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: windows-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - uses: microsoft/setup-msbuild@v2
+
+      - name: Run unit tests
+        run: npm test
+        env:
+          CI: true
+
+      - name: Build Windows installer
+        run: npm run build:win
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-build
+          path: dist/*.exe


### PR DESCRIPTION
## Summary
- add Windows CI workflow
- install pnpm globally before running the CI

## Testing
- `npm test`
- `pnpm --version`


------
https://chatgpt.com/codex/tasks/task_e_6866eb9a18988326b63cf485a3e5781a