### PR TITLE
Fix Windows CI release

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -46,6 +46,7 @@ jobs:
         run: npm run build:win
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Upload installer
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- fix GH_TOKEN for windows release

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686704889f74832684c4aaa58086a930