### PR TITLE
Add strict types and ESLint globals

### DIFF
--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -1,8 +1,9 @@
 // ipcHandlers.ts
 
 import { ipcMain, app } from "electron"
-import { AppState } from "./main"
 import path from "node:path"
+
+import { AppState } from "./main"
 
 const screenshotDir = path.join(app.getPath("userData"), "screenshots")
 const extraScreenshotDir = path.join(app.getPath("userData"), "extra_screenshots")
@@ -34,8 +35,9 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const resolved = validatePath(filePath)
       return await appState.deleteScreenshot(resolved)
-    } catch (error: any) {
-      return { success: false, error: error.message }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      return { success: false, error: message }
     }
   })
 
@@ -94,9 +96,10 @@ export function initializeIpcHandlers(appState: AppState): void {
       appState.clearQueues()
       console.log("Screenshot queues have been cleared.")
       return { success: true }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error resetting queues:", error)
-      return { success: false, error: error.message }
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      return { success: false, error: message }
     }
   })
 
@@ -105,7 +108,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const result = await appState.processingHelper.processAudioBase64(data, mimeType)
       return result
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error in analyze-audio-base64 handler:", error)
       throw error
     }
@@ -117,7 +120,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       const resolved = validatePath(filePath)
       const result = await appState.processingHelper.processAudioFile(resolved)
       return result
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error in analyze-audio-file handler:", error)
       throw error
     }
@@ -131,7 +134,7 @@ export function initializeIpcHandlers(appState: AppState): void {
         .getLLMHelper()
         .analyzeImageFile(resolved)
       return result
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error in analyze-image-file handler:", error)
       throw error
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,9 +1,12 @@
 import { app, BrowserWindow } from "electron"
+
+import { ProblemStatementData } from "../src/types/solutions"
+
 import { initializeIpcHandlers } from "./ipcHandlers"
-import { WindowHelper } from "./WindowHelper"
+import { ProcessingHelper } from "./ProcessingHelper"
 import { ScreenshotHelper } from "./ScreenshotHelper"
 import { ShortcutsHelper } from "./shortcuts"
-import { ProcessingHelper } from "./ProcessingHelper"
+import { WindowHelper } from "./WindowHelper"
 
 export class AppState {
   private static instance: AppState | null = null
@@ -16,13 +19,7 @@ export class AppState {
   // View management
   private view: "queue" | "solutions" = "queue"
 
-  private problemInfo: {
-    problem_statement: string
-    input_format: Record<string, any>
-    output_format: Record<string, any>
-    constraints: Array<Record<string, any>>
-    test_cases: Array<Record<string, any>>
-  } | null = null // Allow null
+  private problemInfo: ProblemStatementData | null = null
 
   private hasDebugged: boolean = false
 
@@ -88,11 +85,11 @@ export class AppState {
     return this.screenshotHelper
   }
 
-  public getProblemInfo(): any {
+  public getProblemInfo(): ProblemStatementData | null {
     return this.problemInfo
   }
 
-  public setProblemInfo(problemInfo: any): void {
+  public setProblemInfo(problemInfo: ProblemStatementData): void {
     this.problemInfo = problemInfo
   }
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,25 @@
 import js from '@eslint/js';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
+import importPlugin from 'eslint-plugin-import';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import perfectionist from 'eslint-plugin-perfectionist';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
-import jsxA11y from 'eslint-plugin-jsx-a11y';
-import importPlugin from 'eslint-plugin-import';
 import unused from 'eslint-plugin-unused-imports';
-import perfectionist from 'eslint-plugin-perfectionist';
+import globals from 'globals';
 
 export default [
+  {
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        window: 'readonly',
+        electronAPI: 'readonly',
+      },
+    },
+  },
   js.configs.recommended,
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import { ToastProvider } from "./components/ui/toast"
-import Queue from "./_pages/Queue"
 import { ToastViewport } from "@radix-ui/react-toast"
 import { useEffect, useRef, useState } from "react"
-import Solutions from "./_pages/Solutions"
 import { QueryClient, QueryClientProvider } from "react-query"
+
+import Queue from "./_pages/Queue"
+import Solutions from "./_pages/Solutions"
+import { ToastProvider } from "./components/ui/toast"
 
 // Global ElectronAPI type is defined in src/types/electron.d.ts
 
@@ -98,7 +99,7 @@ const App: React.FC = () => {
         setView("queue")
         console.log("View reset to 'queue' via Command+R shortcut")
       }),
-      window.electronAPI.onProblemExtracted((data: any) => {
+      window.electronAPI.onProblemExtracted((data) => {
         if (view === "queue") {
           console.log("Problem extracted successfully")
           queryClient.invalidateQueries(["problem_statement"])

--- a/src/components/Solutions/SolutionCommands.tsx
+++ b/src/components/Solutions/SolutionCommands.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react"
 import { IoLogOutOutline } from "react-icons/io5"
 
 interface SolutionCommandsProps {
-  extraScreenshots: any[]
+  extraScreenshots: Array<{ path: string; preview: string }>
   onTooltipVisibilityChange?: (visible: boolean, height: number) => void
 }
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,3 +1,14 @@
+import { ProblemStatementData } from './solutions'
+
+export interface SolutionResult {
+  solution: {
+    code: string
+    thoughts: string[]
+    time_complexity: string
+    space_complexity: string
+  }
+}
+
 export interface ElectronAPI {
   updateContentDimensions: (dimensions: {
     width: number
@@ -12,11 +23,11 @@ export interface ElectronAPI {
   onResetView: (callback: () => void) => () => void
   onSolutionStart: (callback: () => void) => () => void
   onDebugStart: (callback: () => void) => () => void
-  onDebugSuccess: (callback: (data: any) => void) => () => void
+  onDebugSuccess: (callback: (data: SolutionResult) => void) => () => void
   onSolutionError: (callback: (error: string) => void) => () => void
   onProcessingNoScreenshots: (callback: () => void) => () => void
-  onProblemExtracted: (callback: (data: any) => void) => () => void
-  onSolutionSuccess: (callback: (data: any) => void) => () => void
+  onProblemExtracted: (callback: (data: ProblemStatementData) => void) => () => void
+  onSolutionSuccess: (callback: (data: SolutionResult) => void) => () => void
   onSolutionToken: (callback: (token: string) => void) => () => void
   onUnauthorized: (callback: () => void) => () => void
   onDebugError: (callback: (error: string) => void) => () => void

--- a/src/types/solutions.ts
+++ b/src/types/solutions.ts
@@ -9,11 +9,23 @@ export interface SolutionsResponse {
   [key: string]: Solution
 }
 
+export interface ProblemParameter {
+  name: string
+  type: string
+  description?: string
+}
+
+export interface TestCase {
+  input: string
+  output: string
+  explanation?: string
+}
+
 export interface ProblemStatementData {
   problem_statement: string;
   input_format: {
     description: string;
-    parameters: any[];
+    parameters: ProblemParameter[];
   };
   output_format: {
     description: string;
@@ -24,7 +36,7 @@ export interface ProblemStatementData {
     time: string;
     space: string;
   };
-  test_cases: any[];
+  test_cases: TestCase[];
   validation_type: string;
   difficulty: string;
 }


### PR DESCRIPTION
## Summary
- define browser and node globals for ESLint
- tighten types for electron callbacks and solution data
- update app logic to use typed events
- refactor IPC and processing helpers to avoid `any`

## Testing
- `npx eslint . --ext .js,.jsx,.ts,.tsx --fix` *(fails: "Parsing error: \"parserOptions.project\" has been provided for ...)*

------
https://chatgpt.com/codex/tasks/task_e_6867a0a094b48326a44958821350c1fd