### PR TITLE
Update ESLint config and types

### DIFF
--- a/electron/ProcessingHelper.ts
+++ b/electron/ProcessingHelper.ts
@@ -1,8 +1,11 @@
 // ProcessingHelper.ts
 
-import { AppState } from "./main"
-import { LLMHelper } from "./LLMHelper"
 import dotenv from "dotenv"
+
+import type { Parameter, TestCase } from "../src/types/solutions"
+
+import { LLMHelper } from "./LLMHelper"
+import { AppState } from "./main"
 
 dotenv.config()
 
@@ -50,7 +53,7 @@ export class ProcessingHelper {
             this.currentProcessingAbortController.signal
           );
           mainWindow.webContents.send(this.appState.PROCESSING_EVENTS.PROBLEM_EXTRACTED, audioResult);
-          this.appState.setProblemInfo({ problem_statement: audioResult.text, input_format: {}, output_format: {}, constraints: [], test_cases: [] });
+          this.appState.setProblemInfo({ problem_statement: audioResult.text, input_format: {}, output_format: {}, constraints: [], test_cases: [] as TestCase[] });
           return;
         } catch (err: any) {
           console.error('Audio processing error:', err);
@@ -70,10 +73,10 @@ export class ProcessingHelper {
         );
         const problemInfo = {
           problem_statement: imageResult.text,
-          input_format: { description: "Generated from screenshot", parameters: [] as any[] },
+          input_format: { description: "Generated from screenshot", parameters: [] as Parameter[] },
           output_format: { description: "Generated from screenshot", type: "string", subtype: "text" },
           complexity: { time: "N/A", space: "N/A" },
-          test_cases: [] as any[],
+          test_cases: [] as TestCase[],
           validation_type: "manual",
           difficulty: "custom"
         };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,9 +1,12 @@
 import { app, BrowserWindow } from "electron"
+
+import type { ProblemStatementData } from "../src/types/solutions"
+
 import { initializeIpcHandlers } from "./ipcHandlers"
-import { WindowHelper } from "./WindowHelper"
+import { ProcessingHelper } from "./ProcessingHelper"
 import { ScreenshotHelper } from "./ScreenshotHelper"
 import { ShortcutsHelper } from "./shortcuts"
-import { ProcessingHelper } from "./ProcessingHelper"
+import { WindowHelper } from "./WindowHelper"
 
 export class AppState {
   private static instance: AppState | null = null
@@ -16,13 +19,7 @@ export class AppState {
   // View management
   private view: "queue" | "solutions" = "queue"
 
-  private problemInfo: {
-    problem_statement: string
-    input_format: Record<string, any>
-    output_format: Record<string, any>
-    constraints: Array<Record<string, any>>
-    test_cases: Array<Record<string, any>>
-  } | null = null // Allow null
+  private problemInfo: ProblemStatementData | null = null
 
   private hasDebugged: boolean = false
 
@@ -88,11 +85,11 @@ export class AppState {
     return this.screenshotHelper
   }
 
-  public getProblemInfo(): any {
+  public getProblemInfo(): ProblemStatementData | null {
     return this.problemInfo
   }
 
-  public setProblemInfo(problemInfo: any): void {
+  public setProblemInfo(problemInfo: ProblemStatementData): void {
     this.problemInfo = problemInfo
   }
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,25 @@
 import js from '@eslint/js';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
+import importPlugin from 'eslint-plugin-import';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import perfectionist from 'eslint-plugin-perfectionist';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
-import jsxA11y from 'eslint-plugin-jsx-a11y';
-import importPlugin from 'eslint-plugin-import';
 import unused from 'eslint-plugin-unused-imports';
-import perfectionist from 'eslint-plugin-perfectionist';
+import globals from 'globals';
 
 export default [
+  {
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        window: 'readonly',
+        electronAPI: 'readonly',
+      },
+    },
+  },
   js.configs.recommended,
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/src/components/Queue/ScreenshotItem.tsx
+++ b/src/components/Queue/ScreenshotItem.tsx
@@ -1,6 +1,6 @@
+import { X } from "lucide-react"
 // src/components/ScreenshotItem.tsx
 import React from "react"
-import { X } from "lucide-react"
 
 interface Screenshot {
   path: string
@@ -49,7 +49,7 @@ const ScreenshotItem: React.FC<ScreenshotItemProps> = ({
           <button
             onClick={(e) => {
               e.stopPropagation()
-              handleDelete()
+              void handleDelete()
             }}
             className="absolute top-2 left-2 p-1 rounded-full bg-black bg-opacity-50 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300"
             aria-label="Delete screenshot"

--- a/src/components/Solutions/SolutionCommands.tsx
+++ b/src/components/Solutions/SolutionCommands.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react"
 import { IoLogOutOutline } from "react-icons/io5"
 
 interface SolutionCommandsProps {
-  extraScreenshots: any[]
+  extraScreenshots: unknown[]
   onTooltipVisibilityChange?: (visible: boolean, height: number) => void
 }
 
@@ -202,7 +202,9 @@ const SolutionCommands: React.FC<SolutionCommandsProps> = ({
           <button
             className="text-red-500/70 hover:text-red-500/90 transition-colors hover:cursor-pointer"
             title="Sign Out"
-            onClick={() => window.electronAPI.quitApp()}
+            onClick={() => {
+              void window.electronAPI.quitApp()
+            }}
           >
             <IoLogOutOutline className="w-4 h-4" />
           </button>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -12,11 +12,11 @@ export interface ElectronAPI {
   onResetView: (callback: () => void) => () => void
   onSolutionStart: (callback: () => void) => () => void
   onDebugStart: (callback: () => void) => () => void
-  onDebugSuccess: (callback: (data: any) => void) => () => void
+  onDebugSuccess: (callback: (data: unknown) => void) => () => void
   onSolutionError: (callback: (error: string) => void) => () => void
   onProcessingNoScreenshots: (callback: () => void) => () => void
-  onProblemExtracted: (callback: (data: any) => void) => () => void
-  onSolutionSuccess: (callback: (data: any) => void) => () => void
+  onProblemExtracted: (callback: (data: unknown) => void) => () => void
+  onSolutionSuccess: (callback: (data: unknown) => void) => () => void
   onSolutionToken: (callback: (token: string) => void) => () => void
   onUnauthorized: (callback: () => void) => () => void
   onDebugError: (callback: (error: string) => void) => () => void

--- a/src/types/solutions.ts
+++ b/src/types/solutions.ts
@@ -5,6 +5,18 @@ export interface Solution {
   code: string
 }
 
+export interface Parameter {
+  name: string
+  type: string
+  description?: string
+}
+
+export interface TestCase {
+  input: unknown
+  output: unknown
+  description?: string
+}
+
 export interface SolutionsResponse {
   [key: string]: Solution
 }
@@ -13,7 +25,7 @@ export interface ProblemStatementData {
   problem_statement: string;
   input_format: {
     description: string;
-    parameters: any[];
+    parameters: Parameter[];
   };
   output_format: {
     description: string;
@@ -24,7 +36,7 @@ export interface ProblemStatementData {
     time: string;
     space: string;
   };
-  test_cases: any[];
+  test_cases: TestCase[];
   validation_type: string;
   difficulty: string;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/worker-script/node/index.js
+++ b/worker-script/node/index.js
@@ -5,11 +5,12 @@ parentPort.on('message', async (message) => {
   try {
     // Process the message based on its type
     switch (message.type) {
-      case 'process':
+    case 'process': {
         // Add your processing logic here
         const result = await processTask(message.data);
         parentPort.postMessage({ type: 'result', data: result });
         break;
+    }
       
       default:
         parentPort.postMessage({ 


### PR DESCRIPTION
## Summary
- enable browser and node globals for ESLint
- define Parameter and TestCase interfaces
- use new types in electron code
- tweak screenshot and solution components for ESLint
- ignore vitest config and fix worker script

## Testing
- `npm run lint` *(fails: many lint errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_6867b911c2748326a4ac7d32c7afd7dd