### PR TITLE
Fix ESLint globals and tighten types

### DIFF
--- a/electron/ProcessingHelper.ts
+++ b/electron/ProcessingHelper.ts
@@ -1,8 +1,9 @@
 // ProcessingHelper.ts
 
-import { AppState } from "./main"
-import { LLMHelper } from "./LLMHelper"
 import dotenv from "dotenv"
+
+import { LLMHelper } from "./LLMHelper"
+import { AppState } from "./main"
 
 dotenv.config()
 
@@ -52,9 +53,10 @@ export class ProcessingHelper {
           mainWindow.webContents.send(this.appState.PROCESSING_EVENTS.PROBLEM_EXTRACTED, audioResult);
           this.appState.setProblemInfo({ problem_statement: audioResult.text, input_format: {}, output_format: {}, constraints: [], test_cases: [] });
           return;
-        } catch (err: any) {
-          console.error('Audio processing error:', err);
-          mainWindow.webContents.send(this.appState.PROCESSING_EVENTS.INITIAL_SOLUTION_ERROR, err.message);
+        } catch (err: unknown) {
+          const error = err as Error
+          console.error('Audio processing error:', error);
+          mainWindow.webContents.send(this.appState.PROCESSING_EVENTS.INITIAL_SOLUTION_ERROR, error.message);
           return;
         }
       }
@@ -70,18 +72,19 @@ export class ProcessingHelper {
         );
         const problemInfo = {
           problem_statement: imageResult.text,
-          input_format: { description: "Generated from screenshot", parameters: [] as any[] },
+          input_format: { description: "Generated from screenshot", parameters: [] as unknown[] },
           output_format: { description: "Generated from screenshot", type: "string", subtype: "text" },
           complexity: { time: "N/A", space: "N/A" },
-          test_cases: [] as any[],
+          test_cases: [] as unknown[],
           validation_type: "manual",
           difficulty: "custom"
         };
         mainWindow.webContents.send(this.appState.PROCESSING_EVENTS.PROBLEM_EXTRACTED, problemInfo);
         this.appState.setProblemInfo(problemInfo);
-      } catch (error: any) {
-        console.error("Image processing error:", error)
-        mainWindow.webContents.send(this.appState.PROCESSING_EVENTS.INITIAL_SOLUTION_ERROR, error.message)
+      } catch (error: unknown) {
+        const err = error as Error
+        console.error("Image processing error:", err)
+        mainWindow.webContents.send(this.appState.PROCESSING_EVENTS.INITIAL_SOLUTION_ERROR, err.message)
       } finally {
         this.currentProcessingAbortController = null
       }
@@ -131,11 +134,12 @@ export class ProcessingHelper {
           debugResult
         )
 
-      } catch (error: any) {
-        console.error("Debug processing error:", error)
+      } catch (error: unknown) {
+        const err = error as Error
+        console.error("Debug processing error:", err)
         mainWindow.webContents.send(
           this.appState.PROCESSING_EVENTS.DEBUG_ERROR,
-          error.message
+          err.message
         )
       } finally {
         this.currentExtraProcessingAbortController = null

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -1,8 +1,9 @@
 // ipcHandlers.ts
 
 import { ipcMain, app } from "electron"
-import { AppState } from "./main"
 import path from "node:path"
+
+import { AppState } from "./main"
 
 const screenshotDir = path.join(app.getPath("userData"), "screenshots")
 const extraScreenshotDir = path.join(app.getPath("userData"), "extra_screenshots")
@@ -34,8 +35,9 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const resolved = validatePath(filePath)
       return await appState.deleteScreenshot(resolved)
-    } catch (error: any) {
-      return { success: false, error: error.message }
+    } catch (error: unknown) {
+      const err = error as Error
+      return { success: false, error: err.message }
     }
   })
 
@@ -44,7 +46,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       const screenshotPath = await appState.takeScreenshot()
       const preview = await appState.getImagePreview(screenshotPath)
       return { path: screenshotPath, preview }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error("Error taking screenshot:", error)
       throw error
     }
@@ -69,9 +71,9 @@ export function initializeIpcHandlers(appState: AppState): void {
           }))
         )
       }
-      previews.forEach((preview: any) => console.log(preview.path))
+      previews.forEach((preview) => console.log(preview.path))
       return previews
-    } catch (error) {
+    } catch (error: unknown) {
       console.error("Error getting screenshots:", error)
       throw error
     }
@@ -94,9 +96,10 @@ export function initializeIpcHandlers(appState: AppState): void {
       appState.clearQueues()
       console.log("Screenshot queues have been cleared.")
       return { success: true }
-    } catch (error: any) {
-      console.error("Error resetting queues:", error)
-      return { success: false, error: error.message }
+    } catch (error: unknown) {
+      const err = error as Error
+      console.error("Error resetting queues:", err)
+      return { success: false, error: err.message }
     }
   })
 
@@ -105,7 +108,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const result = await appState.processingHelper.processAudioBase64(data, mimeType)
       return result
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error in analyze-audio-base64 handler:", error)
       throw error
     }
@@ -117,7 +120,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       const resolved = validatePath(filePath)
       const result = await appState.processingHelper.processAudioFile(resolved)
       return result
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error in analyze-audio-file handler:", error)
       throw error
     }
@@ -131,7 +134,7 @@ export function initializeIpcHandlers(appState: AppState): void {
         .getLLMHelper()
         .analyzeImageFile(resolved)
       return result
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error in analyze-image-file handler:", error)
       throw error
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,9 +1,10 @@
 import { app, BrowserWindow } from "electron"
+
 import { initializeIpcHandlers } from "./ipcHandlers"
-import { WindowHelper } from "./WindowHelper"
+import { ProcessingHelper } from "./ProcessingHelper"
 import { ScreenshotHelper } from "./ScreenshotHelper"
 import { ShortcutsHelper } from "./shortcuts"
-import { ProcessingHelper } from "./ProcessingHelper"
+import { WindowHelper } from "./WindowHelper"
 
 export class AppState {
   private static instance: AppState | null = null
@@ -18,10 +19,10 @@ export class AppState {
 
   private problemInfo: {
     problem_statement: string
-    input_format: Record<string, any>
-    output_format: Record<string, any>
-    constraints: Array<Record<string, any>>
-    test_cases: Array<Record<string, any>>
+    input_format: Record<string, unknown>
+    output_format: Record<string, unknown>
+    constraints: Array<Record<string, unknown>>
+    test_cases: Array<Record<string, unknown>>
   } | null = null // Allow null
 
   private hasDebugged: boolean = false
@@ -88,11 +89,11 @@ export class AppState {
     return this.screenshotHelper
   }
 
-  public getProblemInfo(): any {
+  public getProblemInfo(): Record<string, unknown> | null {
     return this.problemInfo
   }
 
-  public setProblemInfo(problemInfo: any): void {
+  public setProblemInfo(problemInfo: Record<string, unknown>): void {
     this.problemInfo = problemInfo
   }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -17,11 +17,11 @@ interface ElectronAPI {
   onResetView: (callback: () => void) => () => void
   onSolutionStart: (callback: () => void) => () => void
   onDebugStart: (callback: () => void) => () => void
-  onDebugSuccess: (callback: (data: any) => void) => () => void
+  onDebugSuccess: (callback: (data: unknown) => void) => () => void
   onSolutionError: (callback: (error: string) => void) => () => void
   onProcessingNoScreenshots: (callback: () => void) => () => void
-  onProblemExtracted: (callback: (data: any) => void) => () => void
-  onSolutionSuccess: (callback: (data: any) => void) => () => void
+  onProblemExtracted: (callback: (data: unknown) => void) => () => void
+  onSolutionSuccess: (callback: (data: unknown) => void) => () => void
   onSolutionToken: (callback: (token: string) => void) => () => void
 
   onUnauthorized: (callback: () => void) => () => void
@@ -71,7 +71,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onScreenshotTaken: (
     callback: (data: { path: string; preview: string }) => void
   ) => {
-    const subscription = (_: any, data: { path: string; preview: string }) =>
+    const subscription = (_: unknown, data: { path: string; preview: string }) =>
       callback(data)
     ipcRenderer.on("screenshot-taken", subscription)
     return () => {
@@ -79,7 +79,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     }
   },
   onSolutionsReady: (callback: (solutions: string) => void) => {
-    const subscription = (_: any, solutions: string) => callback(solutions)
+    const subscription = (_: unknown, solutions: string) => callback(solutions)
     ipcRenderer.on("solutions-ready", subscription)
     return () => {
       ipcRenderer.removeListener("solutions-ready", subscription)
@@ -107,22 +107,22 @@ contextBridge.exposeInMainWorld("electronAPI", {
     }
   },
 
-  onDebugSuccess: (callback: (data: any) => void) => {
-    const subscription = (_event: any, data: any) => callback(data)
+  onDebugSuccess: (callback: (data: unknown) => void) => {
+    const subscription = (_event: unknown, data: unknown) => callback(data)
     ipcRenderer.on("debug-success", subscription)
     return () => {
       ipcRenderer.removeListener("debug-success", subscription)
     }
   },
   onDebugError: (callback: (error: string) => void) => {
-    const subscription = (_: any, error: string) => callback(error)
+    const subscription = (_: unknown, error: string) => callback(error)
     ipcRenderer.on(PROCESSING_EVENTS.DEBUG_ERROR, subscription)
     return () => {
       ipcRenderer.removeListener(PROCESSING_EVENTS.DEBUG_ERROR, subscription)
     }
   },
   onSolutionError: (callback: (error: string) => void) => {
-    const subscription = (_: any, error: string) => callback(error)
+    const subscription = (_: unknown, error: string) => callback(error)
     ipcRenderer.on(PROCESSING_EVENTS.INITIAL_SOLUTION_ERROR, subscription)
     return () => {
       ipcRenderer.removeListener(
@@ -139,8 +139,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     }
   },
 
-  onProblemExtracted: (callback: (data: any) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
+  onProblemExtracted: (callback: (data: unknown) => void) => {
+    const subscription = (_: unknown, data: unknown) => callback(data)
     ipcRenderer.on(PROCESSING_EVENTS.PROBLEM_EXTRACTED, subscription)
     return () => {
       ipcRenderer.removeListener(
@@ -149,8 +149,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       )
     }
   },
-  onSolutionSuccess: (callback: (data: any) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
+  onSolutionSuccess: (callback: (data: unknown) => void) => {
+    const subscription = (_: unknown, data: unknown) => callback(data)
     ipcRenderer.on(PROCESSING_EVENTS.SOLUTION_SUCCESS, subscription)
     return () => {
       ipcRenderer.removeListener(
@@ -160,7 +160,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     }
   },
   onSolutionToken: (callback: (token: string) => void) => {
-    const subscription = (_: any, token: string) => callback(token)
+    const subscription = (_: unknown, token: string) => callback(token)
     ipcRenderer.on(PROCESSING_EVENTS.SOLUTION_TOKEN, subscription)
     return () => {
       ipcRenderer.removeListener(

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,31 @@
 import js from '@eslint/js';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
+import importPlugin from 'eslint-plugin-import';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import perfectionist from 'eslint-plugin-perfectionist';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
-import jsxA11y from 'eslint-plugin-jsx-a11y';
-import importPlugin from 'eslint-plugin-import';
 import unused from 'eslint-plugin-unused-imports';
-import perfectionist from 'eslint-plugin-perfectionist';
 
 export default [
+  {
+    languageOptions: {
+      globals: {
+        window: 'readonly',
+        document: 'readonly',
+        navigator: 'readonly',
+        console: 'readonly',
+        process: 'readonly',
+        module: 'readonly',
+        require: 'readonly',
+        __dirname: 'readonly',
+        setTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearTimeout: 'readonly',
+      },
+    },
+  },
   js.configs.recommended,
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import { ToastProvider } from "./components/ui/toast"
-import Queue from "./_pages/Queue"
 import { ToastViewport } from "@radix-ui/react-toast"
 import { useEffect, useRef, useState } from "react"
-import Solutions from "./_pages/Solutions"
 import { QueryClient, QueryClientProvider } from "react-query"
+
+import Queue from "./_pages/Queue"
+import Solutions from "./_pages/Solutions"
+import { ToastProvider } from "./components/ui/toast"
 
 // Global ElectronAPI type is defined in src/types/electron.d.ts
 
@@ -98,7 +99,7 @@ const App: React.FC = () => {
         setView("queue")
         console.log("View reset to 'queue' via Command+R shortcut")
       }),
-      window.electronAPI.onProblemExtracted((data: any) => {
+      window.electronAPI.onProblemExtracted((data: unknown) => {
         if (view === "queue") {
           console.log("Problem extracted successfully")
           queryClient.invalidateQueries(["problem_statement"])

--- a/src/components/Solutions/SolutionCommands.tsx
+++ b/src/components/Solutions/SolutionCommands.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react"
 import { IoLogOutOutline } from "react-icons/io5"
 
 interface SolutionCommandsProps {
-  extraScreenshots: any[]
+  extraScreenshots: Array<{ path: string; preview: string }>
   onTooltipVisibilityChange?: (visible: boolean, height: number) => void
 }
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -12,11 +12,11 @@ export interface ElectronAPI {
   onResetView: (callback: () => void) => () => void
   onSolutionStart: (callback: () => void) => () => void
   onDebugStart: (callback: () => void) => () => void
-  onDebugSuccess: (callback: (data: any) => void) => () => void
+  onDebugSuccess: (callback: (data: unknown) => void) => () => void
   onSolutionError: (callback: (error: string) => void) => () => void
   onProcessingNoScreenshots: (callback: () => void) => () => void
-  onProblemExtracted: (callback: (data: any) => void) => () => void
-  onSolutionSuccess: (callback: (data: any) => void) => () => void
+  onProblemExtracted: (callback: (data: unknown) => void) => () => void
+  onSolutionSuccess: (callback: (data: unknown) => void) => () => void
   onSolutionToken: (callback: (token: string) => void) => () => void
   onUnauthorized: (callback: () => void) => () => void
   onDebugError: (callback: (error: string) => void) => () => void

--- a/src/types/solutions.ts
+++ b/src/types/solutions.ts
@@ -13,7 +13,7 @@ export interface ProblemStatementData {
   problem_statement: string;
   input_format: {
     description: string;
-    parameters: any[];
+    parameters: unknown[];
   };
   output_format: {
     description: string;
@@ -24,7 +24,7 @@ export interface ProblemStatementData {
     time: string;
     space: string;
   };
-  test_cases: any[];
+  test_cases: unknown[];
   validation_type: string;
   difficulty: string;
 }


### PR DESCRIPTION
## Summary
- update ESLint config with Node/Electron globals
- replace `any` usages with stricter types
- adjust solution handlers to cast unknown values

## Testing
- `npm run lint -- --fix` *(fails: 116 errors)*
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867c1ffa7b0832683c0baf61703a4ad