### PR TITLE
Fix dotenv import by adding dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "sharp": "^0.34.2",
         "tailwind-merge": "^3.3.1",
         "tesseract.js": "^6.0.1",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "dotenv": "^16.6.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "sharp": "^0.34.2",
     "tailwind-merge": "^3.3.1",
     "tesseract.js": "^6.0.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "dotenv": "^16.6.1"
   }
 }


### PR DESCRIPTION
## Summary
- add `dotenv` to dependencies so electron build can load `.env`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869288a1cd88326a0bb33e5b65e308f